### PR TITLE
add: Unit Testを行うワークフローファイルの追加

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1åå
+      - uses: julia-actions/setup-julia@v1
         with:
           version: "1.8.5"
       - uses: julia-actions/julia-buildpkg@latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,16 @@
+name: Julia Unit Test
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1åå
+        with:
+          version: "1.8.5"
+      - uses: julia-actions/julia-buildpkg@latest
+      - run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
+      - run: julia --project=. -e 'using Pkg; Pkg.test()'


### PR DESCRIPTION
ref. #6 

## WHY

Unit Testによる CI GREEN を担保しないとマージできないようにしたいから．

## WHAT

PRをトリガーにしてUnit Testを行うワークフローファイルの追加